### PR TITLE
src: make clear that coverage run dates are UTC

### DIFF
--- a/coverage/generate-index-html.py
+++ b/coverage/generate-index-html.py
@@ -62,7 +62,7 @@ with open('out/index.html', 'w') as out:
         <div class="page-content">
           <div class="table">
             <div class="table-header">
-              <div>Date</div>
+              <div>Date (UTC)</div>
               <div>HEAD</div>
               <div>JS Coverage</div>
               <div>C++ Coverage</div>


### PR DESCRIPTION
The presented times may be confusing when displayed without time zone information.

/cc fyi @mhdawson @ryanmurakami 