### PR TITLE
Making coverage table more responsive

### DIFF
--- a/coverage/generate-index-html.py
+++ b/coverage/generate-index-html.py
@@ -32,18 +32,36 @@ with open('out/index.html', 'w') as out:
         main { margin-bottom: 2rem; }
         .table-header,
         .table-row {
+          box-sizing: border-box;
           display: flex;
           width: 100%;
           padding: 2px 10px;
         }
-        .table-header { font-weight: bold; }
+        .table-header { font-weight: bold;}
         .table-header > div,
         .table-row > div {
           flex-grow: 1;
           width: 100px;
         }
         .table-row:nth-child(even) { background-color: #eee; }
-        .sha { font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace; }
+        .sha .cell-value { font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace; }
+        .cell-header { display: none; }
+        @media screen and (min-width: 690px) and (max-width: 850px) {
+          .table-header > div:nth-child(n+3),
+          .table-row > div:nth-child(n+3) {
+            flex-grow: 0.2;
+          }
+          .table-header > div:first-child,
+          .table-row > div:first-child {
+            flex-grow: 0.4;
+          }  
+        }
+        @media screen and (max-width: 690px) {
+          .cell-header { display: block; font-weight: bold; }
+          .table-header { display: none; }
+          .table-row { display: block; }
+          .table-row > div { width: 100%; text-align: center; margin-bottom: 12px;}
+        }
     </style>
   </head>
   <body>
@@ -73,10 +91,10 @@ with open('out/index.html', 'w') as out:
     date = datetime.datetime.strptime(date, '%Y-%m-%dT%H:%M:%S%fZ').strftime("%d/%m/%Y %H:%M")
     out.write('''
             <div class="table-row">
-              <div>{0}</div>
-              <div class="sha"><a href="https://github.com/nodejs/node/commit/{1}">{1}</a></div>
-              <div><a href="coverage-{1}/index.html">{2:05.2f}&nbsp;%</a></div>
-              <div><a href="coverage-{1}/cxxcoverage.html">{3:05.2f}&nbsp;%</a></div>
+              <div><div class="cell-header">Date (UTC)</div><div class="cell-value">{0}</div></div>
+              <div class="sha"><div class="cell-header">HEAD</div><div class="cell-value"><a href="https://github.com/nodejs/node/commit/{1}">{1}</a></div></div>
+              <div><div class="cell-header">JS Coverage</div><div class="cell-value"><a href="coverage-{1}/index.html">{2:05.2f}&nbsp;%</a></div></div>
+              <div><div class="cell-header">C++ Coverage</div><div class="cell-value"><a href="coverage-{1}/cxxcoverage.html">{3:05.2f}&nbsp;%</a></div></div>
             </div>'''.format(date, sha, float(jscov), float(cxxcov)))
   out.write('''
           </div>


### PR DESCRIPTION
I made a few modifications on the template to make the table work on mobile devices, here are some screenshots

width: 1920 px
![cov1914x958](https://cloud.githubusercontent.com/assets/2331645/22908088/b3e1aa52-f233-11e6-8458-9c12ccec674f.png)

width: 1200 px
![cov1207x800](https://cloud.githubusercontent.com/assets/2331645/22908108/c3c6f170-f233-11e6-9675-9643d33059fb.png)

width: 880px
![cov880](https://cloud.githubusercontent.com/assets/2331645/22908119/cf8c8a4c-f233-11e6-9fb2-71bdc0c2ebca.png)

width: 692px
![cov691x799](https://cloud.githubusercontent.com/assets/2331645/22908125/d87412a6-f233-11e6-8331-b48e77521230.png)

width: 320px
![cov331x809](https://cloud.githubusercontent.com/assets/2331645/22908174/134bb5fa-f234-11e6-80d2-dc41cf93beaf.png)

